### PR TITLE
【Servder Side Chalenge 2】エラーメッセージなどを全て多言語化しました

### DIFF
--- a/serverside_challenge_2/challenge/app/controllers/api/calculations_controller.rb
+++ b/serverside_challenge_2/challenge/app/controllers/api/calculations_controller.rb
@@ -12,15 +12,15 @@ module Api
 
     def validate_params!
       if params[:ampere].blank?
-        raise ApplicationError::BadRequestError, '契約アンペア数が入力されていません'
+        raise ApplicationError::BadRequestError, I18n.t('errors.contract_amperage.blank')
       elsif (Regexp.new('^(10|15|20|30|40|50|60)$') =~ params[:ampere]) != 0
-        raise ApplicationError::BadRequestError, '契約アンペア数に不正な値が設定されています'
+        raise ApplicationError::BadRequestError, I18n.t('errors.contract_amperage.invalid')
       end
 
       if params[:usage].blank?
-        raise ApplicationError::BadRequestError, '電気使用量が入力されていません'
+        raise ApplicationError::BadRequestError, I18n.t('errors.usage.blank')
       elsif (Regexp.new('^[0-9]+*$') =~ params[:usage]) != 0
-        raise ApplicationError::BadRequestError, '電気使用量が指定されておりません'
+        raise ApplicationError::BadRequestError, I18n.t('errors.usage.invalid')
       end
     end
   end

--- a/serverside_challenge_2/challenge/app/models/basic_monthly_fee.rb
+++ b/serverside_challenge_2/challenge/app/models/basic_monthly_fee.rb
@@ -22,5 +22,5 @@
 class BasicMonthlyFee < ApplicationRecord
   belongs_to :plan
 
-  validates :contract_amperage, uniqueness: { scope: :plan, message: '同一プランにて同じ値を設定することはできません' }
+  validates :contract_amperage, uniqueness: { scope: :plan, message: :unique_value }
 end

--- a/serverside_challenge_2/challenge/app/models/electricity_usage.rb
+++ b/serverside_challenge_2/challenge/app/models/electricity_usage.rb
@@ -23,8 +23,8 @@
 class ElectricityUsage < ApplicationRecord
   belongs_to :plan
 
-  validates :to, uniqueness: { scope: :plan, message: '同一プランにて同じ値を設定することはできません' }, allow_nil: true
-  validates :from, uniqueness: { scope: :plan, message: '同一プランにて同じ値を設定することはできません' }
+  validates :to, uniqueness: { scope: :plan, message: :not_unique_range }, allow_nil: true
+  validates :from, uniqueness: { scope: :plan, message: :not_unique_range }
 
   include ActiveModel::Validations
   validates_with ::PeriodValidator, fields: %i[from to plan_id]

--- a/serverside_challenge_2/challenge/app/validators/period_validator.rb
+++ b/serverside_challenge_2/challenge/app/validators/period_validator.rb
@@ -3,10 +3,10 @@
 class PeriodValidator < ActiveModel::Validator
   def validate(record)
     if record.from.present? && [record.to, record.from].compact.max == record.from
-      record.errors.add(:base, '終了値が、開始値よりも小さくなっています')
+      record.errors.add(:to, :cannot_assign_short_value_to_from)
     elsif record.from.present? && ElectricityUsage.exists?(from: ..record.from, to: record.to..,
                                                            plan_id: record.plan_id)
-      record.errors.add(:base, '同一プランで重複した値が登録されています')
+      record.errors.add(:base, :not_unique)
     end
   end
 end

--- a/serverside_challenge_2/challenge/app/validators/period_validator.rb
+++ b/serverside_challenge_2/challenge/app/validators/period_validator.rb
@@ -8,7 +8,7 @@ class PeriodValidator < ActiveModel::Validator
       record.errors.add(:to, :cannot_assign_short_value_to_from)
     elsif ElectricityUsage.exists?(from: ..record.from, to: record.to..,
                                    plan_id: record.plan_id)
-                                   record.errors.add(:base, :not_unique)
+      record.errors.add(:base, :not_unique)
     end
   end
 

--- a/serverside_challenge_2/challenge/config/application.rb
+++ b/serverside_challenge_2/challenge/config/application.rb
@@ -26,6 +26,9 @@ module App
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    # 日本で使うことが主目的になるため、日本語化しておく
+    config.i18n.default_locale = :ja
+
     config.autoload_paths += Dir["#{config.root}/lib/errors/"]
   end
 end

--- a/serverside_challenge_2/challenge/config/locales/ja.yml
+++ b/serverside_challenge_2/challenge/config/locales/ja.yml
@@ -1,0 +1,42 @@
+ja:
+  activerecord:
+    models:
+      plan: プラン
+      basic_monthly_fee: 月額料金
+      electricity_usage: 従量料金
+      provider: プロバイダー
+    attributes:
+      plan:
+        name: プラン名
+        provider_id: プロバイダーID
+      basic_monthly_fee:
+        contract_amperage: 契約アンペア数
+        price: 基本料金(円)
+      electricity_usage:
+        from: 電気使用量(開始値)
+        to: 電気使用量(終了値)
+        unit_price: 従量料金単価
+      provider:
+        name: 会社名
+    errors:
+      messages:
+        not_unique: 同じ値を設定することはできません
+      models:
+        electricity_usage:
+          attributes:
+            to:
+              cannot_assign_short_value_to_from: 開始値よりも小さくなっています
+        basic_monthly_fee:
+          attributes:
+            contract_amperage:
+              unique_value: 同一プランにて同じ値を設定することはできません
+  errors:
+    contract_amperage:
+      blank: 契約アンペア数が入力されていません
+      invalid: 契約アンペア数に不正な値が設定されています
+    usage:
+      blank: 電気使用量が入力されていません
+      invalid: 電気使用量に不正な値が設定されています
+
+
+      


### PR DESCRIPTION
## PR の概要
エラーメッセージを全て多言語対応できるように、メッセージ関連を全て言語ファイルにて扱えるようにして、replace しやすいようにする

## 今後実施予定の改修
* API の実装PR https://github.com/enechange/coding-challenge/pull/63
* テストコードの追加 https://github.com/Jcat-aki/coding-challenge/pull/1 
* フロントサイドの追加 ← ここを対応するのは、期日的に間に合うか不明なので、飛ばしております
* （さらに時間があれば...）多言語化対応 https://github.com/Jcat-aki/coding-challenge/pull/2 ← 今ここ


### 気になること
* （おそらく）日本以外だと、請求金額の小数点以下の値がどうなるのかわからないため、今多言語化する必要はなさそうですが、対応してみました